### PR TITLE
Add maintenance mode with IP whitelist

### DIFF
--- a/dcs-stats/header.php
+++ b/dcs-stats/header.php
@@ -1,6 +1,7 @@
 <?php
 // Include path configuration
 require_once __DIR__ . '/config_path.php';
+require_once __DIR__ . '/site_features.php';
 
 // Security headers for protection against common web vulnerabilities
 header("X-Content-Type-Options: nosniff");
@@ -41,6 +42,15 @@ if (file_exists($configFile)) {
 $cspConnectSrc .= " http://localhost:* https://localhost:*";
 
 header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src {$cspConnectSrc};");
+
+if (isFeatureEnabled('maintenance_mode')) {
+    $whitelist = array_filter(array_map('trim', explode(',', getFeatureValue('maintenance_whitelist', ''))));
+    $clientIp = $_SERVER['REMOTE_ADDR'] ?? '';
+    if (!in_array($clientIp, $whitelist)) {
+        include __DIR__ . '/maintenance.php';
+        exit;
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/dcs-stats/maintenance.php
+++ b/dcs-stats/maintenance.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Maintenance mode page
+ */
+
+// Ensure helper functions are available when accessed directly
+require_once __DIR__ . '/config_path.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Maintenance</title>
+    <link rel="stylesheet" href="<?php echo url('styles.php'); ?>">
+    <link rel="stylesheet" href="<?php echo url('styles-mobile.css'); ?>">
+</head>
+<body>
+    <main class="maintenance-page">
+        <img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><line x1='10' y1='10' x2='90' y2='90' stroke='red' stroke-width='10'/><line x1='90' y1='10' x2='10' y2='90' stroke='red' stroke-width='10'/></svg>" alt="Red X" class="maintenance-icon">
+        <h1>Statistics is Temporarily Unavailable</h1>
+        <p>Please try again later.</p>
+    </main>
+</body>
+</html>

--- a/dcs-stats/site-config/api/settings.php
+++ b/dcs-stats/site-config/api/settings.php
@@ -81,6 +81,9 @@ switch ($method) {
         if (isset($input['features']['squadron_homepage_text'])) {
             $allFeatures['squadron_homepage_text'] = $input['features']['squadron_homepage_text'];
         }
+        if (isset($input['features']['maintenance_whitelist'])) {
+            $allFeatures['maintenance_whitelist'] = $input['features']['maintenance_whitelist'];
+        }
         
         // Apply dependencies
         $dependencies = getFeatureDependencies();

--- a/dcs-stats/site-config/settings.php
+++ b/dcs-stats/site-config/settings.php
@@ -39,6 +39,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $allFeatures[$key] = isset($_POST['features'][$key]);
             }
         }
+
+        // Save maintenance whitelist
+        $allFeatures['maintenance_whitelist'] = trim($_POST['maintenance_whitelist'] ?? '');
         
         // Note: Discord and Squadron settings are now handled in separate pages
         
@@ -273,7 +276,12 @@ $pageTitle = 'Site Settings';
                                 </div>
                             <?php endforeach; ?>
                         </div>
-                        
+
+                        <div class="setting-item" style="margin-top:20px;">
+                            <label for="maintenance_whitelist">Maintenance Mode Whitelist IPs (comma-separated)</label>
+                            <input type="text" id="maintenance_whitelist" name="maintenance_whitelist" value="<?= e($currentFeatures['maintenance_whitelist'] ?? '') ?>" placeholder="e.g. 127.0.0.1, 192.168.1.1" />
+                        </div>
+
                         <div class="settings-actions">
                             <button type="submit" class="btn btn-primary">Save Settings</button>
                             <span class="text-muted">Changes take effect immediately</span>

--- a/dcs-stats/site_features.php
+++ b/dcs-stats/site_features.php
@@ -94,6 +94,8 @@ function loadSiteFeatures() {
         // Global Features
         'show_discord_link' => true,
         'show_last_update' => true,
+        'maintenance_mode' => false,
+        'maintenance_whitelist' => '',
         
         // Custom Links
         'show_squadron_homepage' => false,
@@ -211,7 +213,8 @@ function getFeatureGroups() {
         ],
         'Global Settings' => [
             'show_discord_link' => 'Show Discord Link',
-            'show_last_update' => 'Show Last Update Time'
+            'show_last_update' => 'Show Last Update Time',
+            'maintenance_mode' => 'Enable Maintenance Mode'
         ]
     ];
 }

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -951,3 +951,19 @@ button[onclick*="search"]:hover {
     font-size: 2.5rem;
     margin-bottom: 10px;
 }
+
+/* Maintenance page styling */
+.maintenance-page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 1rem;
+}
+
+.maintenance-icon {
+    width: 100px;
+    height: 100px;
+}


### PR DESCRIPTION
## Summary
- add configurable maintenance_mode feature with IP whitelist
- display maintenance page with red X when site is in maintenance, using site-wide styling

## Testing
- `php -l dcs-stats/maintenance.php`
- `php -l dcs-stats/header.php`
- `php -l dcs-stats/site-config/settings.php`
- `php -l dcs-stats/site-config/api/settings.php`
- `php -l dcs-stats/site_features.php`


------
https://chatgpt.com/codex/tasks/task_e_688f79b778448323ab64f89907444b32