### PR TITLE
feat: add IP auto-fill for maintenance whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,6 +663,9 @@ header("Content-Security-Policy: default-src 'self';
 - **Improved:** Error logging with automatic rotation
 - **Maintained:** All existing `config.ini` settings continue to work
 
+### 🛠 Maintenance Whitelist Improvements
+- Added "Add My IP" button on settings page to auto-fill the current administrator's IP into the maintenance mode whitelist.
+
 ---
 
 ## 🤝 Contributors

--- a/dcs-stats/site-config/css/admin.css
+++ b/dcs-stats/site-config/css/admin.css
@@ -374,6 +374,17 @@ textarea.form-control {
     flex: 1;
 }
 
+/* Input with button */
+.input-with-button {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+}
+
+.input-with-button input {
+    flex: 1;
+}
+
 /* Pagination */
 .pagination {
     display: flex;

--- a/dcs-stats/site-config/settings.php
+++ b/dcs-stats/site-config/settings.php
@@ -277,9 +277,12 @@ $pageTitle = 'Site Settings';
                             <?php endforeach; ?>
                         </div>
 
-                        <div class="setting-item" style="margin-top:20px;">
+                        <div class="setting-item" style="margin-top:20px; flex-direction: column; align-items: flex-start;">
                             <label for="maintenance_whitelist">Maintenance Mode Whitelist IPs (comma-separated)</label>
-                            <input type="text" id="maintenance_whitelist" name="maintenance_whitelist" value="<?= e($currentFeatures['maintenance_whitelist'] ?? '') ?>" placeholder="e.g. 127.0.0.1, 192.168.1.1" />
+                            <div class="input-with-button">
+                                <input type="text" id="maintenance_whitelist" name="maintenance_whitelist" value="<?= e($currentFeatures['maintenance_whitelist'] ?? '') ?>" placeholder="e.g. 127.0.0.1, 192.168.1.1" />
+                                <button type="button" class="btn btn-secondary btn-small" id="add-current-ip">Add My IP</button>
+                            </div>
                         </div>
 
                         <div class="settings-actions">
@@ -373,13 +376,27 @@ $pageTitle = 'Site Settings';
                 expandAllBtn.textContent = 'Expand All Groups';
                 expandAllBtn.onclick = function() { toggleAllGroups(false); };
                 bulkActions.appendChild(expandAllBtn);
-                
+
                 const collapseAllBtn = document.createElement('button');
                 collapseAllBtn.type = 'button';
                 collapseAllBtn.className = 'btn btn-secondary';
                 collapseAllBtn.textContent = 'Collapse All Groups';
                 collapseAllBtn.onclick = function() { toggleAllGroups(true); };
                 bulkActions.appendChild(collapseAllBtn);
+            }
+
+            const addIpBtn = document.getElementById('add-current-ip');
+            if (addIpBtn) {
+                const currentIp = '<?= e($_SERVER['REMOTE_ADDR'] ?? '') ?>';
+                addIpBtn.addEventListener('click', function() {
+                    const input = document.getElementById('maintenance_whitelist');
+                    if (!input) return;
+                    const ips = input.value.split(',').map(ip => ip.trim()).filter(ip => ip);
+                    if (!ips.includes(currentIp)) {
+                        ips.push(currentIp);
+                        input.value = ips.join(', ');
+                    }
+                });
             }
         });
         


### PR DESCRIPTION
## Summary
- add Add My IP button to maintenance whitelist settings
- style maintenance whitelist input and button
- document maintenance whitelist improvement

## Testing
- `php -l dcs-stats/site-config/settings.php`
- `php -l dcs-stats/header.php`


------
https://chatgpt.com/codex/tasks/task_e_688f91f2f9bc8323bdece52fb446bb3a