### PR TITLE
Add maintenance whitelist with IP auto-fill

### DIFF
--- a/dcs-stats/header.php
+++ b/dcs-stats/header.php
@@ -41,6 +41,21 @@ if (file_exists($configFile)) {
 $cspConnectSrc .= " http://localhost:* https://localhost:*";
 
 header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src {$cspConnectSrc};");
+
+// Maintenance mode check
+$maintenanceFile = __DIR__ . '/site-config/data/maintenance.json';
+if (file_exists($maintenanceFile)) {
+    $maintenance = json_decode(file_get_contents($maintenanceFile), true);
+    if (!empty($maintenance['enabled'])) {
+        $allowed = $maintenance['ip_whitelist'] ?? [];
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        if (!in_array($ip, $allowed)) {
+            http_response_code(503);
+            echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Maintenance</title></head><body><h1>Maintenance Mode</h1><p>The site is currently under maintenance. Please check back later.</p></body></html>';
+            exit;
+        }
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/dcs-stats/site-config/admin_functions.php
+++ b/dcs-stats/site-config/admin_functions.php
@@ -370,3 +370,28 @@ function getPagination($totalItems, $perPage, $currentPage, $baseUrl) {
     
     return $html;
 }
+
+/**
+ * Load maintenance configuration
+ */
+function loadMaintenanceConfig() {
+    $file = __DIR__ . '/data/maintenance.json';
+    $defaults = ['enabled' => false, 'ip_whitelist' => []];
+
+    if (file_exists($file)) {
+        $data = json_decode(file_get_contents($file), true);
+        if (is_array($data)) {
+            return array_merge($defaults, $data);
+        }
+    }
+
+    return $defaults;
+}
+
+/**
+ * Save maintenance configuration
+ */
+function saveMaintenanceConfig($config) {
+    $file = __DIR__ . '/data/maintenance.json';
+    return file_put_contents($file, json_encode($config, JSON_PRETTY_PRINT)) !== false;
+}

--- a/dcs-stats/site-config/maintenance.php
+++ b/dcs-stats/site-config/maintenance.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Maintenance Mode Settings
+ */
+
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/admin_functions.php';
+
+// Require admin login and permission
+requireAdmin();
+requirePermission('change_settings');
+
+// Current admin
+$currentAdmin = getCurrentAdmin();
+
+// Load current configuration
+$maintenance = loadMaintenanceConfig();
+
+$message = '';
+$messageType = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Verify CSRF token
+    if (!isset($_POST['csrf_token']) || !verifyCSRFToken($_POST['csrf_token'])) {
+        $message = ERROR_MESSAGES['csrf_invalid'];
+        $messageType = 'error';
+    } else {
+        // Update maintenance mode
+        $maintenance['enabled'] = isset($_POST['enabled']);
+
+        // Add IP to whitelist if provided
+        $ip = trim($_POST['ip_address'] ?? '');
+        if ($ip !== '') {
+            if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                if (!in_array($ip, $maintenance['ip_whitelist'])) {
+                    $maintenance['ip_whitelist'][] = $ip;
+                }
+            } else {
+                $message = 'Invalid IP address';
+                $messageType = 'error';
+            }
+        }
+
+        if ($messageType !== 'error') {
+            saveMaintenanceConfig($maintenance);
+            logAdminActivity('MAINTENANCE_UPDATE', $_SESSION['admin_id'], 'settings', 'maintenance', $maintenance);
+            $message = 'Maintenance settings updated';
+            $messageType = 'success';
+        }
+    }
+}
+
+$pageTitle = 'Maintenance Whitelist';
+$currentIP = $_SERVER['REMOTE_ADDR'] ?? '';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $pageTitle ?> - Carrier Air Wing Command</title>
+    <link rel="stylesheet" href="css/admin.css">
+</head>
+<body>
+<div class="admin-wrapper">
+    <?php include 'nav.php'; ?>
+    <main class="admin-main">
+        <header class="admin-header">
+            <h1><?= $pageTitle ?></h1>
+            <div class="admin-user-menu">
+                <div class="admin-user-info">
+                    <div class="admin-username"><?= e($currentAdmin['username']) ?></div>
+                    <div class="admin-role"><?= getRoleBadge($currentAdmin['role']) ?></div>
+                </div>
+                <a href="logout.php" class="btn btn-secondary btn-small">Logout</a>
+            </div>
+        </header>
+        <div class="admin-content">
+            <?php if ($message): ?>
+                <div class="alert alert-<?= $messageType === 'success' ? 'success' : 'error' ?>">
+                    <?= e($message) ?>
+                </div>
+            <?php endif; ?>
+            <form method="POST">
+                <?= csrfField() ?>
+                <div class="form-group">
+                    <label>
+                        <input type="checkbox" name="enabled" <?= $maintenance['enabled'] ? 'checked' : '' ?>>
+                        Enable Maintenance Mode
+                    </label>
+                </div>
+                <div class="form-group">
+                    <label for="ip_address">Whitelist IP</label>
+                    <div class="d-flex gap-1">
+                        <input type="text" name="ip_address" id="ip_address" class="form-control" placeholder="127.0.0.1">
+                        <button type="button" class="btn btn-secondary" onclick="autofillIP()">Use My IP</button>
+                    </div>
+                </div>
+                <div class="btn-group">
+                    <button type="submit" class="btn btn-primary">Save Settings</button>
+                </div>
+            </form>
+            <?php if (!empty($maintenance['ip_whitelist'])): ?>
+                <div class="card mt-2">
+                    <div class="card-header">
+                        <h2 class="card-title">Current Whitelist</h2>
+                    </div>
+                    <div class="card-content">
+                        <ul>
+                            <?php foreach ($maintenance['ip_whitelist'] as $ip): ?>
+                                <li><?= e($ip) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                </div>
+            <?php endif; ?>
+        </div>
+    </main>
+</div>
+<script>
+function autofillIP() {
+    document.getElementById('ip_address').value = '<?= $currentIP ?>';
+}
+</script>
+</body>
+</html>

--- a/dcs-stats/site-config/nav.php
+++ b/dcs-stats/site-config/nav.php
@@ -46,7 +46,7 @@ if (!isset($currentAdmin)) {
             </li>
             <?php endif; ?>
             <?php if (hasPermission('change_settings')): ?>
-            <?php $isSettingsPage = in_array(basename($_SERVER['PHP_SELF']), ['settings.php', 'api_settings.php', 'themes.php', 'discord_settings.php', 'squadron_settings.php', 'admins.php', 'permissions.php']); ?>
+<?php $isSettingsPage = in_array(basename($_SERVER['PHP_SELF']), ['settings.php', 'api_settings.php', 'themes.php', 'discord_settings.php', 'squadron_settings.php', 'admins.php', 'permissions.php', 'maintenance.php']); ?>
             <li class="nav-dropdown <?= $isSettingsPage ? 'open' : '' ?>">
                 <a href="#" class="nav-dropdown-toggle <?= $isSettingsPage ? 'active' : '' ?>">
                     <span class="nav-icon">⚙️</span>
@@ -86,6 +86,12 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
+                    <li>
+                        <a href="maintenance.php" <?= basename($_SERVER['PHP_SELF']) === 'maintenance.php' ? 'class="active"' : '' ?>>
+                            <span class="nav-icon">🛠️</span>
+                            Maintenance
+                        </a>
+                    </li>
                     <?php if ($currentAdmin['role'] === ROLE_AIR_BOSS): // Only Air Boss can access Navigation Settings ?>
                     <li>
                         <a href="discord_settings.php" <?= basename($_SERVER['PHP_SELF']) === 'discord_settings.php' ? 'class="active"' : '' ?>>
@@ -173,7 +179,7 @@ document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('click', function(e) {
         if (!e.target.closest('.nav-dropdown')) {
             const currentPath = window.location.pathname;
-            const settingsPages = ['settings.php', 'api_settings.php', 'themes.php', 'discord_settings.php', 'squadron_settings.php', 'admins.php'];
+            const settingsPages = ['settings.php', 'api_settings.php', 'themes.php', 'discord_settings.php', 'squadron_settings.php', 'admins.php', 'maintenance.php'];
             const isOnSettingsPage = settingsPages.some(page => currentPath.includes(page));
             
             if (!isOnSettingsPage) {


### PR DESCRIPTION
## Summary
- Add admin Maintenance Whitelist page with auto-fill button and styling
- Persist maintenance settings and IP whitelist
- Enforce maintenance whitelist in site header and link from admin navigation

## Testing
- `php -l dcs-stats/site-config/admin_functions.php`
- `php -l dcs-stats/site-config/maintenance.php`
- `php -l dcs-stats/site-config/nav.php`
- `php -l dcs-stats/header.php`


------
https://chatgpt.com/codex/tasks/task_e_688f9458f3908323a442f88afe1e6033