### PR TITLE
Restrict maintenance and update features to Air Boss

### DIFF
--- a/dcs-stats/site-config/api/update.php
+++ b/dcs-stats/site-config/api/update.php
@@ -5,6 +5,12 @@ require_once __DIR__ . '/../admin_functions.php';
 requireAdmin();
 requirePermission('change_settings');
 
+$currentAdmin = getCurrentAdmin();
+if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
+    http_response_code(403);
+    exit('Access denied');
+}
+
 set_time_limit(0);
 header('Content-Type: text/plain; charset=utf-8');
 header('Cache-Control: no-cache');

--- a/dcs-stats/site-config/maintenance.php
+++ b/dcs-stats/site-config/maintenance.php
@@ -13,6 +13,11 @@ requirePermission('change_settings');
 // Current admin
 $currentAdmin = getCurrentAdmin();
 
+if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
+    header('Location: index.php?error=access_denied');
+    exit();
+}
+
 // Load current configuration
 $maintenance = loadMaintenanceConfig();
 

--- a/dcs-stats/site-config/nav.php
+++ b/dcs-stats/site-config/nav.php
@@ -86,6 +86,7 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
+                    <?php if ($currentAdmin['role'] === ROLE_AIR_BOSS): ?>
                     <li>
                         <a href="maintenance.php" <?= basename($_SERVER['PHP_SELF']) === 'maintenance.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🛠️</span>
@@ -98,6 +99,7 @@ if (!isset($currentAdmin)) {
                             Update
                         </a>
                     </li>
+                    <?php endif; ?>
                     <?php if ($currentAdmin['role'] === ROLE_AIR_BOSS): // Only Air Boss can access Navigation Settings ?>
                     <li>
                         <a href="discord_settings.php" <?= basename($_SERVER['PHP_SELF']) === 'discord_settings.php' ? 'class="active"' : '' ?>>

--- a/dcs-stats/site-config/update.php
+++ b/dcs-stats/site-config/update.php
@@ -9,6 +9,11 @@ requireAdmin();
 requirePermission('change_settings');
 
 $currentAdmin = getCurrentAdmin();
+if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
+    header('Location: index.php?error=access_denied');
+    exit();
+}
+
 $pageTitle = 'Update Dashboard';
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- Limit visibility of maintenance and update navigation items to Air Boss role
- Block non–Air Boss roles from accessing maintenance and update pages or update API

## Testing
- `php -l dcs-stats/site-config/nav.php`
- `php -l dcs-stats/site-config/maintenance.php`
- `php -l dcs-stats/site-config/update.php`
- `php -l dcs-stats/site-config/api/update.php`


------
https://chatgpt.com/codex/tasks/task_e_6891159207c88323954f7a89895c6c6d