### PR TITLE
Fix navigation menu and implement proper permission-based access control

### DIFF
--- a/dcs-stats/site-config/api/update.php
+++ b/dcs-stats/site-config/api/update.php
@@ -3,13 +3,7 @@ require_once __DIR__ . '/../auth.php';
 require_once __DIR__ . '/../admin_functions.php';
 
 requireAdmin();
-requirePermission('change_settings');
-
-$currentAdmin = getCurrentAdmin();
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    http_response_code(403);
-    exit('Access denied');
-}
+requirePermission('manage_updates');
 
 set_time_limit(0);
 header('Content-Type: text/plain; charset=utf-8');

--- a/dcs-stats/site-config/config.php
+++ b/dcs-stats/site-config/config.php
@@ -39,7 +39,15 @@ const ROLE_PERMISSIONS = [
         'export_data',
         'view_logs',
         'manage_admins',
-        'change_settings'
+        'change_settings',
+        'manage_maintenance',
+        'manage_updates',
+        'manage_api',
+        'manage_themes',
+        'manage_features',
+        'manage_permissions',
+        'manage_discord',
+        'manage_squadrons'
     ],
     ROLE_LSO => [             // Monitors pilot statistics and landings
         'view_dashboard',

--- a/dcs-stats/site-config/maintenance.php
+++ b/dcs-stats/site-config/maintenance.php
@@ -8,15 +8,10 @@ require_once __DIR__ . '/admin_functions.php';
 
 // Require admin login and permission
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_maintenance');
 
 // Current admin
 $currentAdmin = getCurrentAdmin();
-
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    header('Location: index.php?error=access_denied');
-    exit();
-}
 
 // Load current configuration
 $maintenance = loadMaintenanceConfig();

--- a/dcs-stats/site-config/nav.php
+++ b/dcs-stats/site-config/nav.php
@@ -62,7 +62,7 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
-                    <?php if ($currentAdmin['role'] === ROLE_AIR_BOSS): // Only Air Boss can manage permissions ?>
+                    <?php if (hasPermission('manage_permissions')): ?>
                     <li>
                         <a href="permissions.php" <?= basename($_SERVER['PHP_SELF']) === 'permissions.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🛡️</span>
@@ -70,7 +70,7 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
-                    <?php if (hasPermission('manage_api') || $currentAdmin['role'] === ROLE_AIR_BOSS): ?>
+                    <?php if (hasPermission('manage_api')): ?>
                     <li>
                         <a href="api_settings.php" <?= basename($_SERVER['PHP_SELF']) === 'api_settings.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🔌</span>
@@ -78,7 +78,7 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
-                    <?php if (hasPermission('manage_features') || hasPermission('change_settings')): ?>
+                    <?php if (hasPermission('manage_features')): ?>
                     <li>
                         <a href="settings.php" <?= basename($_SERVER['PHP_SELF']) === 'settings.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🎛️</span>
@@ -86,13 +86,15 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
-                    <?php if ($currentAdmin['role'] === ROLE_AIR_BOSS): ?>
+                    <?php if (hasPermission('manage_maintenance')): ?>
                     <li>
                         <a href="maintenance.php" <?= basename($_SERVER['PHP_SELF']) === 'maintenance.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🛠️</span>
                             Maintenance
                         </a>
                     </li>
+                    <?php endif; ?>
+                    <?php if (hasPermission('manage_updates')): ?>
                     <li>
                         <a href="update.php" <?= basename($_SERVER['PHP_SELF']) === 'update.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🔄</span>
@@ -100,13 +102,15 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
-                    <?php if ($currentAdmin['role'] === ROLE_AIR_BOSS): // Only Air Boss can access Navigation Settings ?>
+                    <?php if (hasPermission('manage_discord')): ?>
                     <li>
                         <a href="discord_settings.php" <?= basename($_SERVER['PHP_SELF']) === 'discord_settings.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🎮</span>
                             Discord Link
                         </a>
                     </li>
+                    <?php endif; ?>
+                    <?php if (hasPermission('manage_squadrons')): ?>
                     <li>
                         <a href="squadron_settings.php" <?= basename($_SERVER['PHP_SELF']) === 'squadron_settings.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">✈️</span>
@@ -114,7 +118,7 @@ if (!isset($currentAdmin)) {
                         </a>
                     </li>
                     <?php endif; ?>
-                    <?php if (hasPermission('manage_themes') || hasPermission('change_settings')): ?>
+                    <?php if (hasPermission('manage_themes')): ?>
                     <li>
                         <a href="themes.php" <?= basename($_SERVER['PHP_SELF']) === 'themes.php' ? 'class="active"' : '' ?>>
                             <span class="nav-icon">🎨</span>

--- a/dcs-stats/site-config/update.php
+++ b/dcs-stats/site-config/update.php
@@ -6,13 +6,9 @@ require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/admin_functions.php';
 
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_updates');
 
 $currentAdmin = getCurrentAdmin();
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    header('Location: index.php?error=access_denied');
-    exit();
-}
 
 $pageTitle = 'Update Dashboard';
 ?>


### PR DESCRIPTION
## Summary
- Fixed missing menu items (themes, site features, etc.) in admin navigation
- Implemented clean permission-based access control system
- Removed redundant permission/role checks

## Problem
The navigation menu had several issues:
1. Menu items like "Themes" and "Site Features" weren't showing because they checked for non-existent permissions
2. The code mixed permission-based and role-based access control, creating redundancy
3. Several permissions referenced in nav.php weren't defined in config.php

## Solution
1. Added all missing permissions to config.php:
   - `manage_api`
   - `manage_themes` 
   - `manage_features`
   - `manage_permissions`
   - `manage_discord`
   - `manage_squadrons`

2. Updated all access control to use consistent permission checks:
   - Removed direct role comparisons like `$currentAdmin['role'] === ROLE_AIR_BOSS`
   - Removed redundant checks like `hasPermission('manage_api') || $currentAdmin['role'] === ROLE_AIR_BOSS`
   - Now everything uses clean `hasPermission()` checks

3. Maintains exact same functionality - Air Boss still has full access through permissions

## Test plan
- [x] Verify Air Boss can see all menu items
- [x] Verify LSO users see only permitted items
- [x] Test that all admin pages load correctly when accessed
- [x] Confirm no functionality has changed, only implementation

🤖 Generated with [Claude Code](https://claude.ai/code)