### PR TITLE
Fix settings menu visibility and permission alignment

### DIFF
--- a/dcs-stats/site-config/api_settings.php
+++ b/dcs-stats/site-config/api_settings.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../api_config_helper.php';
 
 // Require admin login and permission
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_api');
 
 // Get current admin
 $currentAdmin = getCurrentAdmin();

--- a/dcs-stats/site-config/discord_settings.php
+++ b/dcs-stats/site-config/discord_settings.php
@@ -9,7 +9,7 @@ require_once dirname(__DIR__) . '/site_features.php';
 
 // Require admin login and permission
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_discord');
 
 // Get current admin
 $currentAdmin = getCurrentAdmin();

--- a/dcs-stats/site-config/nav.php
+++ b/dcs-stats/site-config/nav.php
@@ -45,7 +45,7 @@ if (!isset($currentAdmin)) {
                 </a>
             </li>
             <?php endif; ?>
-            <?php if (hasPermission('change_settings')): ?>
+            <?php if (hasPermission('change_settings') || hasPermission('manage_admins') || hasPermission('manage_permissions') || hasPermission('manage_api') || hasPermission('manage_features') || hasPermission('manage_maintenance') || hasPermission('manage_updates') || hasPermission('manage_discord') || hasPermission('manage_squadrons') || hasPermission('manage_themes')): ?>
 <?php $isSettingsPage = in_array(basename($_SERVER['PHP_SELF']), ['settings.php', 'api_settings.php', 'themes.php', 'discord_settings.php', 'squadron_settings.php', 'admins.php', 'permissions.php', 'maintenance.php', 'update.php']); ?>
             <li class="nav-dropdown <?= $isSettingsPage ? 'open' : '' ?>">
                 <a href="#" class="nav-dropdown-toggle <?= $isSettingsPage ? 'active' : '' ?>">

--- a/dcs-stats/site-config/settings.php
+++ b/dcs-stats/site-config/settings.php
@@ -9,7 +9,7 @@ require_once dirname(__DIR__) . '/site_features.php';
 
 // Require admin login and permission
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_features');
 
 // Get current admin
 $currentAdmin = getCurrentAdmin();

--- a/dcs-stats/site-config/squadron_settings.php
+++ b/dcs-stats/site-config/squadron_settings.php
@@ -9,7 +9,7 @@ require_once dirname(__DIR__) . '/site_features.php';
 
 // Require admin login and permission
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_squadrons');
 
 // Get current admin
 $currentAdmin = getCurrentAdmin();

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/admin_functions.php';
 
 // Require admin login and permission
 requireAdmin();
-requirePermission('change_settings');
+requirePermission('manage_themes');
 
 // Get current admin to check specific permissions
 $currentAdmin = getCurrentAdmin();


### PR DESCRIPTION
## Summary
- Fixed Settings dropdown menu not showing despite having permissions
- Aligned page permission checks with navigation menu expectations
- Ensures all settings pages are accessible when appropriate permissions exist

## Problem
After the previous PR was merged, the Settings dropdown and its items (like Themes) weren't showing in the navigation menu because:
1. The Settings dropdown only showed if user had `change_settings` permission
2. Individual pages were checking for `change_settings` instead of their specific permissions
3. This created a mismatch between navigation visibility and page access

## Solution
1. Updated all settings pages to use their specific permissions:
   - `themes.php` → `manage_themes`
   - `settings.php` → `manage_features`
   - `api_settings.php` → `manage_api`
   - `discord_settings.php` → `manage_discord`
   - `squadron_settings.php` → `manage_squadrons`

2. Fixed Settings dropdown to show if user has ANY settings-related permission

## Test plan
- [x] Verify Settings dropdown appears for Air Boss
- [x] Verify all menu items within Settings are visible
- [x] Confirm each settings page uses its specific permission
- [x] Test that pages are accessible when navigated to

🤖 Generated with [Claude Code](https://claude.ai/code)