### PR TITLE
Complete fix for admin navigation and permission system

### DIFF
--- a/dcs-stats/site-config/api/settings.php
+++ b/dcs-stats/site-config/api/settings.php
@@ -20,7 +20,7 @@ if (!isAdminLoggedIn()) {
 }
 
 // Check permissions
-if (!hasPermission('change_settings')) {
+if (!hasPermission('manage_features')) {
     http_response_code(403);
     echo json_encode(['error' => 'Insufficient permissions']);
     exit;

--- a/dcs-stats/site-config/api_settings.php
+++ b/dcs-stats/site-config/api_settings.php
@@ -14,12 +14,6 @@ requirePermission('manage_api');
 // Get current admin
 $currentAdmin = getCurrentAdmin();
 
-// Only Air Boss can change API settings
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    header('Location: index.php?error=access_denied');
-    exit();
-}
-
 // Load current API configuration with auto-fixing
 $configResult = loadApiConfigWithFix();
 $apiConfig = $configResult['config'];

--- a/dcs-stats/site-config/config.php
+++ b/dcs-stats/site-config/config.php
@@ -47,7 +47,8 @@ const ROLE_PERMISSIONS = [
         'manage_features',
         'manage_permissions',
         'manage_discord',
-        'manage_squadrons'
+        'manage_squadrons',
+        'ban_players'
     ],
     ROLE_LSO => [             // Monitors pilot statistics and landings
         'view_dashboard',

--- a/dcs-stats/site-config/css/admin.css
+++ b/dcs-stats/site-config/css/admin.css
@@ -120,7 +120,7 @@ body {
 }
 
 .nav-dropdown-menu.open {
-    max-height: 300px;
+    max-height: 500px;
 }
 
 .nav-dropdown-menu li a {

--- a/dcs-stats/site-config/discord_settings.php
+++ b/dcs-stats/site-config/discord_settings.php
@@ -14,12 +14,6 @@ requirePermission('manage_discord');
 // Get current admin
 $currentAdmin = getCurrentAdmin();
 
-// Only Air Boss can change Discord settings
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    header('Location: index.php?error=access_denied');
-    exit();
-}
-
 // Handle form submission
 $message = '';
 $messageType = '';

--- a/dcs-stats/site-config/permissions.php
+++ b/dcs-stats/site-config/permissions.php
@@ -7,13 +7,9 @@
 require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/admin_functions.php';
 
-// Require admin login and Air Boss role
+// Require admin login and permission
 requireAdmin();
-if (getCurrentAdmin()['role'] !== ROLE_AIR_BOSS) {
-    $_SESSION['error'] = 'Only Air Boss can manage permissions';
-    header('Location: ' . url('site-config/'));
-    exit;
-}
+requirePermission('manage_permissions');
 
 $message = '';
 $error = '';

--- a/dcs-stats/site-config/settings.php
+++ b/dcs-stats/site-config/settings.php
@@ -14,12 +14,6 @@ requirePermission('manage_features');
 // Get current admin
 $currentAdmin = getCurrentAdmin();
 
-// Only Air Boss can change site features
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    header('Location: index.php?error=access_denied');
-    exit();
-}
-
 // Handle form submission
 $message = '';
 $messageType = '';

--- a/dcs-stats/site-config/squadron_settings.php
+++ b/dcs-stats/site-config/squadron_settings.php
@@ -14,12 +14,6 @@ requirePermission('manage_squadrons');
 // Get current admin
 $currentAdmin = getCurrentAdmin();
 
-// Only Air Boss can change Squadron settings
-if ($currentAdmin['role'] !== ROLE_AIR_BOSS) {
-    header('Location: index.php?error=access_denied');
-    exit();
-}
-
 // Handle form submission
 $message = '';
 $messageType = '';


### PR DESCRIPTION
## Summary
- Removed all redundant role checks that were preventing access
- Fixed CSS issue preventing themes menu from showing
- Completed the permission-based access control implementation

## Problems Fixed

### 1. Redundant Role Checks
Several files had hardcoded role checks AFTER `requirePermission()` calls, making the permission system ineffective:
- `squadron_settings.php` 
- `settings.php`
- `discord_settings.php` 
- `api_settings.php`

These have all been removed since `requirePermission()` already handles access control.

### 2. Navigation Menu Cut Off
The Settings dropdown had `max-height: 300px` but contained 9 items (~360px+ total height). This caused the Themes menu item to be hidden. Increased to 500px.

### 3. Incorrect API Permission
The `api/settings.php` endpoint was checking for `change_settings` instead of `manage_features`.

### 4. Missing Permission
Added `ban_players` permission that was referenced but not defined.

## Changes Made
- Removed 4 redundant role check blocks
- Updated CSS max-height for dropdown menu
- Fixed API permission check
- Added missing permission definition
- Removed debug files

## Test Plan
- [x] Verify all menu items are visible in Settings dropdown
- [x] Test each admin page loads with proper permissions
- [x] Confirm no functionality is lost
- [x] Verify permissions are enforced correctly

🤖 Generated with [Claude Code](https://claude.ai/code)