### PR TITLE
feat(theme): allow font customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the DCS Statistics Website Uploader project.
 
 ## [Unreleased] - 2025-07-31
 
+### 🖌️ Theme Customization Options
+- Added global font family selection in theme management for greater frontend personalization.
+
 ### 🎨 **Modern Professional Interface Overhaul**
 
 #### Cinematic Header Design

--- a/dcs-stats/header.php
+++ b/dcs-stats/header.php
@@ -62,15 +62,16 @@ $frameAncestors = (isset($_GET['preview']) && $_GET['preview'] === '1') ? " fram
 header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src {$cspConnectSrc};" . $frameAncestors);
 
 // Handle theme preview parameters
-$previewColors = null;
+$previewVars = null;
 if (isset($_GET['preview']) && $_GET['preview'] === '1') {
-    $previewColors = [
+    $previewVars = [
         'primary_color' => isset($_GET['primary']) ? '#' . $_GET['primary'] : null,
         'secondary_color' => isset($_GET['secondary']) ? '#' . $_GET['secondary'] : null,
         'background_color' => isset($_GET['background']) ? '#' . $_GET['background'] : null,
         'text_color' => isset($_GET['text']) ? '#' . $_GET['text'] : null,
         'link_color' => isset($_GET['link']) ? '#' . $_GET['link'] : null,
         'border_color' => isset($_GET['border']) ? '#' . $_GET['border'] : null,
+        'font_family' => isset($_GET['font']) ? urldecode($_GET['font']) : null,
     ];
 }
 
@@ -103,12 +104,12 @@ if (file_exists($maintenanceFile)) {
   <?php if (file_exists(__DIR__ . '/custom_theme.css')): ?>
   <link rel="stylesheet" href="<?php echo url('custom_theme.css'); ?>" />
   <?php endif; ?>
-  <?php if ($previewColors): ?>
+  <?php if ($previewVars): ?>
   <style>
     :root {
-      <?php foreach ($previewColors as $var => $color): ?>
-      <?php if ($color): ?>
-      --<?php echo $var; ?>: <?php echo $color; ?> !important;
+      <?php foreach ($previewVars as $var => $value): ?>
+      <?php if ($value): ?>
+      --<?php echo $var; ?>: <?php echo htmlspecialchars($value); ?> !important;
       <?php endif; ?>
       <?php endforeach; ?>
     }

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -15,12 +15,13 @@ html {
     --text_color: #ffffff;
     --link_color: #4a9eff;
     --border_color: #556b2f;
+    --font_family: Arial, sans-serif;
 }
 
 body {
     background-color: var(--background_color);
     color: var(--text_color);
-    font-family: Arial, sans-serif;
+    font-family: var(--font_family);
     margin: 0;
     padding: 0;
     overflow-x: hidden;


### PR DESCRIPTION
## Summary
- allow selecting global font family in theme management
- wire font variable through preview, theme saving, and default styles
- document new theme customization option

## Testing
- `php -l dcs-stats/site-config/themes.php`
- `php -l dcs-stats/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0ba4a44508323ab4fa98b8903ab8b