### PR TITLE
feat: add theme color options

### DIFF
--- a/dcs-stats/header.php
+++ b/dcs-stats/header.php
@@ -71,6 +71,10 @@ if (isset($_GET['preview']) && $_GET['preview'] === '1') {
         'text_color' => isset($_GET['text']) ? '#' . $_GET['text'] : null,
         'link_color' => isset($_GET['link']) ? '#' . $_GET['link'] : null,
         'border_color' => isset($_GET['border']) ? '#' . $_GET['border'] : null,
+        'title_color' => isset($_GET['title']) ? '#' . $_GET['title'] : null,
+        'title_color_secondary' => isset($_GET['title_secondary']) ? '#' . $_GET['title_secondary'] : null,
+        'table_color' => isset($_GET['table']) ? '#' . $_GET['table'] : null,
+        'table_header_color' => isset($_GET['table_header']) ? '#' . $_GET['table_header'] : null,
     ];
 }
 

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -219,7 +219,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'background_color' => $_POST['background_color'] ?? '',
                     'text_color' => $_POST['text_color'] ?? '',
                     'link_color' => $_POST['link_color'] ?? '',
-                    'border_color' => $_POST['border_color'] ?? ''
+                    'border_color' => $_POST['border_color'] ?? '',
+                    'title_color' => $_POST['title_color'] ?? '',
+                    'title_color_secondary' => $_POST['title_color_secondary'] ?? '',
+                    'table_color' => $_POST['table_color'] ?? '',
+                    'table_header_color' => $_POST['table_header_color'] ?? ''
                 ];
                 
                 // Generate CSS variables
@@ -296,7 +300,11 @@ $customColors = [
     'background_color' => '#0f0f0f',
     'text_color' => '#e0e0e0',
     'link_color' => '#4a9eff',
-    'border_color' => '#333333'
+    'border_color' => '#333333',
+    'title_color' => '#ffffff',
+    'title_color_secondary' => '#4CAF50',
+    'table_color' => '#2c2c2c',
+    'table_header_color' => '#4CAF50'
 ];
 
 $customCSS = __DIR__ . '/../custom_theme.css';
@@ -604,6 +612,10 @@ $pageTitle = 'Theme Management';
                         'text' => substr($customColors['text_color'], 1),
                         'link' => substr($customColors['link_color'], 1),
                         'border' => substr($customColors['border_color'], 1),
+                        'title' => substr($customColors['title_color'], 1),
+                        'title_secondary' => substr($customColors['title_color_secondary'], 1),
+                        'table' => substr($customColors['table_color'], 1),
+                        'table_header' => substr($customColors['table_header_color'], 1),
                     ];
                     // Build URL to parent directory
                     $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
@@ -675,8 +687,32 @@ $pageTitle = 'Theme Management';
                                 
                                 <div class="color-input-group">
                                     <label for="border_color" title="Border and accent color">Border/Accent Color:</label>
-                                    <input type="color" id="border_color" name="border_color" 
+                                    <input type="color" id="border_color" name="border_color"
                                            value="<?= htmlspecialchars($customColors['border_color']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="title_color" title="Site title color">Site Title Color:</label>
+                                    <input type="color" id="title_color" name="title_color"
+                                           value="<?= htmlspecialchars($customColors['title_color']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="title_color_secondary" title="Site title gradient end color">Site Title Color 2:</label>
+                                    <input type="color" id="title_color_secondary" name="title_color_secondary"
+                                           value="<?= htmlspecialchars($customColors['title_color_secondary']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="table_color" title="Table background color">Table Color:</label>
+                                    <input type="color" id="table_color" name="table_color"
+                                           value="<?= htmlspecialchars($customColors['table_color']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="table_header_color" title="Table header text color">Table Header Color:</label>
+                                    <input type="color" id="table_header_color" name="table_header_color"
+                                           value="<?= htmlspecialchars($customColors['table_header_color']) ?>">
                                 </div>
                             </div>
                             
@@ -845,7 +881,11 @@ $pageTitle = 'Theme Management';
                 'background': document.getElementById('background_color').value.replace('#', ''),
                 'text': document.getElementById('text_color').value.replace('#', ''),
                 'link': document.getElementById('link_color').value.replace('#', ''),
-                'border': document.getElementById('border_color').value.replace('#', '')
+                'border': document.getElementById('border_color').value.replace('#', ''),
+                'title': document.getElementById('title_color').value.replace('#', ''),
+                'title_secondary': document.getElementById('title_color_secondary').value.replace('#', ''),
+                'table': document.getElementById('table_color').value.replace('#', ''),
+                'table_header': document.getElementById('table_header_color').value.replace('#', '')
             };
             
             // Build URL with preview parameters
@@ -1018,7 +1058,11 @@ $pageTitle = 'Theme Management';
                 'background_color': '#121212',
                 'text_color': '#ffffff',
                 'link_color': '#4a9eff',
-                'border_color': '#556b2f'
+                'border_color': '#556b2f',
+                'title_color': '#ffffff',
+                'title_color_secondary': '#4CAF50',
+                'table_color': '#2c2c2c',
+                'table_header_color': '#4CAF50'
             };
             
             // Set the color inputs to default values

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -710,7 +710,7 @@ $pageTitle = 'Theme Management';
                                 </div>
 
                                 <div class="color-input-group">
-                                    <label for="table_header_color" title="Table header text color">Table Header Color:</label>
+                                    <label for="table_header_color" title="Table header text color">Table Header Text:</label>
                                     <input type="color" id="table_header_color" name="table_header_color"
                                            value="<?= htmlspecialchars($customColors['table_header_color']) ?>">
                                 </div>

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -99,9 +99,7 @@ body {
     font-weight: 800;
     color: var(--title_color);
     margin: 0;
-    text-shadow:
-        0 0 20px color-mix(in srgb, var(--title_color) 50%, var(--title_color_secondary) 50%),
-        2px 2px 4px rgba(0, 0, 0, 0.8);
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
     letter-spacing: -0.5px;
     background: linear-gradient(
         135deg,

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -100,10 +100,15 @@ body {
     color: var(--title_color);
     margin: 0;
     text-shadow:
-        0 0 20px var(--title_color_secondary),
+        0 0 20px color-mix(in srgb, var(--title_color) 50%, var(--title_color_secondary) 50%),
         2px 2px 4px rgba(0, 0, 0, 0.8);
     letter-spacing: -0.5px;
-    background: linear-gradient(135deg, var(--title_color) 0%, var(--title_color_secondary) 100%);
+    background: linear-gradient(
+        135deg,
+        var(--title_color) 0%,
+        color-mix(in srgb, var(--title_color) 70%, var(--title_color_secondary) 30%) 50%,
+        var(--title_color_secondary) 100%
+    );
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -15,6 +15,10 @@ html {
     --text_color: #ffffff;
     --link_color: #4a9eff;
     --border_color: #556b2f;
+    --title_color: #ffffff;
+    --title_color_secondary: #4CAF50;
+    --table_color: #2c2c2c;
+    --table_header_color: #4CAF50;
 }
 
 body {
@@ -93,13 +97,13 @@ body {
 .site-title {
     font-size: 2.2rem;
     font-weight: 800;
-    color: #ffffff;
+    color: var(--title_color);
     margin: 0;
-    text-shadow: 
-        0 0 20px rgba(76, 175, 80, 0.6),
+    text-shadow:
+        0 0 20px var(--title_color_secondary),
         2px 2px 4px rgba(0, 0, 0, 0.8);
     letter-spacing: -0.5px;
-    background: linear-gradient(135deg, #ffffff 0%, #4CAF50 100%);
+    background: linear-gradient(135deg, var(--title_color) 0%, var(--title_color_secondary) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -107,7 +111,7 @@ body {
 
 .site-subtitle {
     font-size: 0.9rem;
-    color: #e0e0e0;
+    color: var(--text_color);
     margin: 0;
     font-weight: 500;
     text-transform: uppercase;
@@ -559,7 +563,7 @@ h2 {
 }
 
 .pagination-controls span {
-  color: #fff;
+  color: var(--text_color);
   margin: 0 10px;
 }
 
@@ -575,25 +579,25 @@ h2 {
 table {
   width: 100%;
   border-collapse: collapse;
-  background: linear-gradient(135deg, #2c2c2c 0%, #1e1e1e 100%);
-  color: #fff;
+  background-color: var(--table_color);
+  color: var(--text_color);
   overflow: hidden;
 }
 
 th, td {
   padding: 14px 18px;
   text-align: left;
-  border-bottom: 1px solid rgba(76, 175, 80, 0.2);
+  border-bottom: 1px solid var(--border_color);
 }
 
 th {
-  background-color: rgba(76, 175, 80, 0.1);
+  background-color: var(--table_color);
   font-weight: bold;
-  color: #4CAF50;
+  color: var(--table_header_color);
   text-transform: uppercase;
   letter-spacing: 1px;
   font-size: 0.9rem;
-  border-bottom: 2px solid rgba(76, 175, 80, 0.3);
+  border-bottom: 2px solid var(--border_color);
 }
 
 tr {
@@ -607,7 +611,7 @@ tbody tr:nth-child(even) {
 tbody tr:hover {
   background-color: rgba(76, 175, 80, 0.1);
   transform: translateX(2px);
-  box-shadow: -2px 0 0 #4CAF50;
+  box-shadow: -2px 0 0 var(--table_header_color);
 }
 
 /* Unified Search Styling */


### PR DESCRIPTION
## Summary
- allow admins to configure site title, table, and table header colors via Themes page
- apply new CSS variables for title, table background, and table header styling
- support previewing of new color options
- ensure logo uses only site title color
- support configurable site title gradient with secondary color option

## Testing
- `php -l dcs-stats/styles.css`
- `php -l dcs-stats/header.php`
- `php -l dcs-stats/site-config/themes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0bf910a8083239dba6313c35ec4be