### PR TITLE
feat: add configurable nav link color

### DIFF
--- a/dcs-stats/header.php
+++ b/dcs-stats/header.php
@@ -71,6 +71,7 @@ if (isset($_GET['preview']) && $_GET['preview'] === '1') {
         'text_color' => isset($_GET['text']) ? '#' . $_GET['text'] : null,
         'link_color' => isset($_GET['link']) ? '#' . $_GET['link'] : null,
         'border_color' => isset($_GET['border']) ? '#' . $_GET['border'] : null,
+        'nav_link_color' => isset($_GET['navlink']) ? '#' . $_GET['navlink'] : null,
     ];
 }
 

--- a/dcs-stats/header.php
+++ b/dcs-stats/header.php
@@ -72,6 +72,8 @@ if (isset($_GET['preview']) && $_GET['preview'] === '1') {
         'link_color' => isset($_GET['link']) ? '#' . $_GET['link'] : null,
         'border_color' => isset($_GET['border']) ? '#' . $_GET['border'] : null,
         'nav_link_color' => isset($_GET['navlink']) ? '#' . $_GET['navlink'] : null,
+        'nav_link_hover_bg' => isset($_GET['navhoverbg']) ? '#' . $_GET['navhoverbg'] : null,
+        'nav_link_hover_color' => isset($_GET['navhover']) ? '#' . $_GET['navhover'] : null,
     ];
 }
 

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -683,7 +683,7 @@ $pageTitle = 'Theme Management';
                                 </div>
 
                                 <div class="color-input-group">
-                                    <label for="nav_link_color" title="Navigation link text color">Navigation Link Color:</label>
+                                    <label for="nav_link_color" title="Navigation text color">Navigation Text Color:</label>
                                     <input type="color" id="nav_link_color" name="nav_link_color"
                                            value="<?= htmlspecialchars($customColors['nav_link_color']) ?>">
                                 </div>

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -219,7 +219,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'background_color' => $_POST['background_color'] ?? '',
                     'text_color' => $_POST['text_color'] ?? '',
                     'link_color' => $_POST['link_color'] ?? '',
-                    'border_color' => $_POST['border_color'] ?? ''
+                    'border_color' => $_POST['border_color'] ?? '',
+                    'nav_link_color' => $_POST['nav_link_color'] ?? ''
                 ];
                 
                 // Generate CSS variables
@@ -296,7 +297,8 @@ $customColors = [
     'background_color' => '#0f0f0f',
     'text_color' => '#e0e0e0',
     'link_color' => '#4a9eff',
-    'border_color' => '#333333'
+    'border_color' => '#333333',
+    'nav_link_color' => '#c2d4c9'
 ];
 
 $customCSS = __DIR__ . '/../custom_theme.css';
@@ -604,6 +606,7 @@ $pageTitle = 'Theme Management';
                         'text' => substr($customColors['text_color'], 1),
                         'link' => substr($customColors['link_color'], 1),
                         'border' => substr($customColors['border_color'], 1),
+                        'navlink' => substr($customColors['nav_link_color'], 1),
                     ];
                     // Build URL to parent directory
                     $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
@@ -675,8 +678,14 @@ $pageTitle = 'Theme Management';
                                 
                                 <div class="color-input-group">
                                     <label for="border_color" title="Border and accent color">Border/Accent Color:</label>
-                                    <input type="color" id="border_color" name="border_color" 
+                                    <input type="color" id="border_color" name="border_color"
                                            value="<?= htmlspecialchars($customColors['border_color']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="nav_link_color" title="Navigation link text color">Navigation Link Color:</label>
+                                    <input type="color" id="nav_link_color" name="nav_link_color"
+                                           value="<?= htmlspecialchars($customColors['nav_link_color']) ?>">
                                 </div>
                             </div>
                             
@@ -845,7 +854,8 @@ $pageTitle = 'Theme Management';
                 'background': document.getElementById('background_color').value.replace('#', ''),
                 'text': document.getElementById('text_color').value.replace('#', ''),
                 'link': document.getElementById('link_color').value.replace('#', ''),
-                'border': document.getElementById('border_color').value.replace('#', '')
+                'border': document.getElementById('border_color').value.replace('#', ''),
+                'navlink': document.getElementById('nav_link_color').value.replace('#', '')
             };
             
             // Build URL with preview parameters
@@ -1018,7 +1028,8 @@ $pageTitle = 'Theme Management';
                 'background_color': '#121212',
                 'text_color': '#ffffff',
                 'link_color': '#4a9eff',
-                'border_color': '#556b2f'
+                'border_color': '#556b2f',
+                'nav_link_color': '#c2d4c9'
             };
             
             // Set the color inputs to default values

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -220,7 +220,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'text_color' => $_POST['text_color'] ?? '',
                     'link_color' => $_POST['link_color'] ?? '',
                     'border_color' => $_POST['border_color'] ?? '',
-                    'nav_link_color' => $_POST['nav_link_color'] ?? ''
+                    'nav_link_color' => $_POST['nav_link_color'] ?? '',
+                    'nav_link_hover_bg' => $_POST['nav_link_hover_bg'] ?? '',
+                    'nav_link_hover_color' => $_POST['nav_link_hover_color'] ?? ''
                 ];
                 
                 // Generate CSS variables
@@ -298,7 +300,9 @@ $customColors = [
     'text_color' => '#e0e0e0',
     'link_color' => '#4a9eff',
     'border_color' => '#333333',
-    'nav_link_color' => '#c2d4c9'
+    'nav_link_color' => '#c2d4c9',
+    'nav_link_hover_bg' => '#2e3e47',
+    'nav_link_hover_color' => '#ffffff'
 ];
 
 $customCSS = __DIR__ . '/../custom_theme.css';
@@ -607,6 +611,8 @@ $pageTitle = 'Theme Management';
                         'link' => substr($customColors['link_color'], 1),
                         'border' => substr($customColors['border_color'], 1),
                         'navlink' => substr($customColors['nav_link_color'], 1),
+                        'navhoverbg' => substr($customColors['nav_link_hover_bg'], 1),
+                        'navhover' => substr($customColors['nav_link_hover_color'], 1),
                     ];
                     // Build URL to parent directory
                     $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
@@ -686,6 +692,18 @@ $pageTitle = 'Theme Management';
                                     <label for="nav_link_color" title="Navigation text color">Navigation Text Color:</label>
                                     <input type="color" id="nav_link_color" name="nav_link_color"
                                            value="<?= htmlspecialchars($customColors['nav_link_color']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="nav_link_hover_bg" title="Navigation hover background">Nav Hover Background:</label>
+                                    <input type="color" id="nav_link_hover_bg" name="nav_link_hover_bg"
+                                           value="<?= htmlspecialchars($customColors['nav_link_hover_bg']) ?>">
+                                </div>
+
+                                <div class="color-input-group">
+                                    <label for="nav_link_hover_color" title="Navigation hover text color">Nav Hover Text:</label>
+                                    <input type="color" id="nav_link_hover_color" name="nav_link_hover_color"
+                                           value="<?= htmlspecialchars($customColors['nav_link_hover_color']) ?>">
                                 </div>
                             </div>
                             
@@ -855,7 +873,9 @@ $pageTitle = 'Theme Management';
                 'text': document.getElementById('text_color').value.replace('#', ''),
                 'link': document.getElementById('link_color').value.replace('#', ''),
                 'border': document.getElementById('border_color').value.replace('#', ''),
-                'navlink': document.getElementById('nav_link_color').value.replace('#', '')
+                'navlink': document.getElementById('nav_link_color').value.replace('#', ''),
+                'navhoverbg': document.getElementById('nav_link_hover_bg').value.replace('#', ''),
+                'navhover': document.getElementById('nav_link_hover_color').value.replace('#', '')
             };
             
             // Build URL with preview parameters
@@ -1029,7 +1049,9 @@ $pageTitle = 'Theme Management';
                 'text_color': '#ffffff',
                 'link_color': '#4a9eff',
                 'border_color': '#556b2f',
-                'nav_link_color': '#c2d4c9'
+                'nav_link_color': '#c2d4c9',
+                'nav_link_hover_bg': '#2e3e47',
+                'nav_link_hover_color': '#ffffff'
             };
             
             // Set the color inputs to default values

--- a/dcs-stats/site-config/themes.php
+++ b/dcs-stats/site-config/themes.php
@@ -347,10 +347,10 @@ $pageTitle = 'Theme Management';
         
         .color-inputs {
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: repeat(4, 1fr);
             gap: 20px;
             margin-top: 20px;
-            max-width: 600px;
+            max-width: 1000px;
         }
         
         .color-input-group {

--- a/dcs-stats/styles-mobile.css
+++ b/dcs-stats/styles-mobile.css
@@ -226,7 +226,8 @@ html, body {
     }
     
     .nav-link:hover {
-        background: rgba(76, 175, 80, 0.2);
+        background-color: var(--nav_link_hover_bg);
+        color: var(--nav_link_hover_color);
     }
     
     /* Main content adjustments */
@@ -485,7 +486,8 @@ html, body {
 /* Touch-friendly hover states */
 @media (hover: none) and (pointer: coarse) {
     .nav-link:hover {
-        background: transparent;
+        background-color: transparent;
+        color: var(--nav_link_color);
     }
     
     .nav-link:active {

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -16,6 +16,8 @@ html {
     --link_color: #4a9eff;
     --border_color: #556b2f;
     --nav_link_color: #c2d4c9;
+    --nav_link_hover_bg: #2e3e47;
+    --nav_link_hover_color: #ffffff;
 }
 
 body {
@@ -431,8 +433,8 @@ h2 {
 
 .nav-link:hover,
 .nav-link:focus {
-    background-color: #2e3e47;
-    color: #ffffff;
+    background-color: var(--nav_link_hover_bg);
+    color: var(--nav_link_hover_color);
 }
 
 .nav-link:active {

--- a/dcs-stats/styles.css
+++ b/dcs-stats/styles.css
@@ -15,6 +15,7 @@ html {
     --text_color: #ffffff;
     --link_color: #4a9eff;
     --border_color: #556b2f;
+    --nav_link_color: #c2d4c9;
 }
 
 body {
@@ -420,7 +421,7 @@ h2 {
 .nav-link {
     display: block;
     padding: 14px 20px;
-    color: #c2d4c9;
+    color: var(--nav_link_color);
     text-decoration: none;
     font-weight: bold;
     text-transform: uppercase;


### PR DESCRIPTION
## Summary
- allow theme config to set navigation link color and preview it live
- expose nav link color picker in admin UI with default restoration
- apply nav link CSS variable in core styles

## Testing
- `php -l dcs-stats/site-config/themes.php`
- `php -l dcs-stats/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68a191b784fc8323b5ad5307cda87e56