### PR TITLE
Add zip extension requirement to installer

### DIFF
--- a/dcs-stats/site-config/install.php
+++ b/dcs-stats/site-config/install.php
@@ -44,7 +44,7 @@ if (version_compare(PHP_VERSION, '7.4.0', '<')) {
 }
 
 // Check required extensions
-$required_extensions = ['json', 'session', 'openssl', 'mbstring'];
+$required_extensions = ['json', 'session', 'openssl', 'mbstring', 'zip'];
 $missing_extensions = [];
 
 foreach ($required_extensions as $ext) {
@@ -188,7 +188,7 @@ if (!$is_cli) {
                     <?= version_compare(PHP_VERSION, '7.4.0', '>=') ? '✓' : '✗' ?> PHP version <?= PHP_VERSION ?> (7.4+ required)
                 </p>
                 <?php
-                $required_extensions = ['json', 'session', 'openssl', 'mbstring'];
+                $required_extensions = ['json', 'session', 'openssl', 'mbstring', 'zip'];
                 foreach ($required_extensions as $ext) {
                     $loaded = extension_loaded($ext);
                     echo '<p class="' . ($loaded ? 'success' : 'error') . '">';


### PR DESCRIPTION
## Summary
- Require PHP zip extension during installation
- Display zip extension status in system requirements list

## Testing
- `php -l dcs-stats/site-config/install.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1c0bba828832387c95f21f170c57f