### PR TITLE
Honor settings that disable major site sections

### DIFF
--- a/dcs-stats/index.php
+++ b/dcs-stats/index.php
@@ -11,8 +11,18 @@ include 'header.php';
 
 <?php
 // Check if this is a fresh install
-$isConfigured = file_exists(__DIR__ . '/api_config.json') || 
+$isConfigured = file_exists(__DIR__ . '/api_config.json') ||
                 file_exists(__DIR__ . '/site-config/data/users.json');
+
+// If homepage is disabled and site is configured, show message
+if (!isFeatureEnabled('nav_home') && $isConfigured) {
+    echo '<main><div class="alert" style="text-align: center; padding: 50px;">'
+       . '<h2>Homepage Disabled</h2>'
+       . '<p>The homepage is currently disabled.</p>'
+       . '</div></main>';
+    include 'footer.php';
+    exit;
+}
 
 if (!$isConfigured):
 ?>

--- a/dcs-stats/leaderboard.php
+++ b/dcs-stats/leaderboard.php
@@ -6,7 +6,17 @@ if (session_status() === PHP_SESSION_NONE) {
 include "header.php"; 
 require_once __DIR__ . '/site_features.php';
 require_once __DIR__ . '/table-responsive.php';
-include "nav.php"; ?>
+include "nav.php";
+
+if (!isFeatureEnabled('nav_leaderboard')) {
+    echo '<main><div class="alert" style="text-align: center; padding: 50px;">'
+       . '<h2>Leaderboard Disabled</h2>'
+       . '<p>The leaderboard is currently disabled.</p>'
+       . '</div></main>';
+    include 'footer.php';
+    exit;
+}
+?>
 
 <style>
   /* Professional Leaderboard Styling */

--- a/dcs-stats/nav.php
+++ b/dcs-stats/nav.php
@@ -60,6 +60,42 @@ if (file_exists($menuConfigFile)) {
         $menuItems = $savedMenu;
     }
 }
+// Apply feature flags to standard navigation items
+foreach ($menuItems as &$item) {
+    switch ($item['url'] ?? '') {
+        case 'index.php':
+            if (!isFeatureEnabled('nav_home')) {
+                $item['enabled'] = false;
+            }
+            break;
+        case 'leaderboard.php':
+            if (!isFeatureEnabled('nav_leaderboard')) {
+                $item['enabled'] = false;
+            }
+            break;
+        case 'pilot_statistics.php':
+            if (!isFeatureEnabled('nav_pilot_statistics')) {
+                $item['enabled'] = false;
+            }
+            break;
+        case 'pilot_credits.php':
+            if (!isFeatureEnabled('nav_pilot_credits')) {
+                $item['enabled'] = false;
+            }
+            break;
+        case 'squadrons.php':
+            if (!isFeatureEnabled('nav_squadrons')) {
+                $item['enabled'] = false;
+            }
+            break;
+        case 'servers.php':
+            if (!isFeatureEnabled('nav_servers')) {
+                $item['enabled'] = false;
+            }
+            break;
+    }
+}
+unset($item);
 // Check if menu config exists, if not check for Discord/Squadron links to add
 $hasDiscordInMenu = false;
 $hasSquadronInMenu = false;

--- a/dcs-stats/pilot_statistics.php
+++ b/dcs-stats/pilot_statistics.php
@@ -10,6 +10,17 @@ include 'header.php';
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <?php include 'nav.php'; ?>
 
+<?php
+if (!isFeatureEnabled('nav_pilot_statistics')) {
+    echo '<main><div class="alert" style="text-align: center; padding: 50px;">'
+       . '<h2>Pilot Statistics Disabled</h2>'
+       . '<p>The pilot statistics page is currently disabled.</p>'
+       . '</div></main>';
+    include 'footer.php';
+    exit;
+}
+?>
+
 <main>
     <div class="dashboard-header">
         <h1>Pilot Statistics</h1>


### PR DESCRIPTION
## Summary
- Hide standard navigation links when their corresponding feature is disabled
- Show a disabled message on the home, leaderboard, and pilot statistics pages when those features are turned off

## Testing
- `php -l nav.php`
- `php -l index.php`
- `php -l leaderboard.php`
- `php -l pilot_statistics.php`


------
https://chatgpt.com/codex/tasks/task_e_68a22225fc2c832393675bb865b425e6