### PR TITLE
Fix DCSServerBot REST API integration (X-API-Key, GET verbs, field mapping, healthcheck)

### DIFF
--- a/dcs-stats/api_client.php
+++ b/dcs-stats/api_client.php
@@ -130,14 +130,14 @@ class DCSServerBotAPIClient {
      * Get top players by kills
      */
     public function getTopKills() {
-        return $this->makeRequest('POST', '/topkills');
+        return $this->makeRequest('GET', '/topkills');
     }
     
     /**
      * Get top players by kill/death ratio
      */
     public function getTopKDR() {
-        return $this->makeRequest('POST', '/topkdr');
+        return $this->makeRequest('GET', '/topkdr');
     }
     
     /**

--- a/dcs-stats/api_client.php
+++ b/dcs-stats/api_client.php
@@ -44,7 +44,7 @@ class DCSServerBotAPIClient {
         ];
         
         if ($this->apiKey) {
-            $headers[] = 'Authorization: Bearer ' . $this->apiKey;
+            $headers[] = 'X-API-Key: ' . $this->apiKey;
         }
         
         // Set method and data

--- a/dcs-stats/api_proxy.php
+++ b/dcs-stats/api_proxy.php
@@ -50,17 +50,28 @@ curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_TIMEOUT, $apiConfig['timeout'] ?? 30);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
+// Build headers — forward the API key to the upstream API if configured.
+// DCSServerBot's REST API requires X-API-Key (Bearer is rejected).
+$headers = [];
+if (!empty($apiConfig['api_key'])) {
+    $headers[] = 'X-API-Key: ' . $apiConfig['api_key'];
+}
+
 // Set method and data
 if ($method === 'POST') {
     curl_setopt($ch, CURLOPT_POST, true);
-    
+
     // Use form-urlencoded for POST data
     if (!empty($data)) {
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/x-www-form-urlencoded']);
+        $headers[] = 'Content-Type: application/x-www-form-urlencoded';
     } else {
         curl_setopt($ch, CURLOPT_POSTFIELDS, '');
     }
+}
+
+if (!empty($headers)) {
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 }
 
 // Execute request

--- a/dcs-stats/get_leaderboard_api.php
+++ b/dcs-stats/get_leaderboard_api.php
@@ -36,9 +36,9 @@ try {
         $stats[] = [
             'rank' => $index + 1,
             'name' => htmlspecialchars($player['nick'] ?? 'Unknown', ENT_QUOTES, 'UTF-8'),
-            'kills' => $player['AAkills'] ?? 0,
+            'kills' => $player['kills'] ?? 0,
             'deaths' => $player['deaths'] ?? 0,
-            'kd_ratio' => $player['AAKDR'] ?? 0,
+            'kd_ratio' => $player['kdr'] ?? 0,
             // These fields are not available in the current API
             'sorties' => 0,
             'flight_hours' => 0,

--- a/dcs-stats/health-check.php
+++ b/dcs-stats/health-check.php
@@ -1,0 +1,1 @@
+<?php http_response_code(200); echo "OK"; ?>


### PR DESCRIPTION
## Summary

The dashboard's DCSServerBot REST API integration has four distinct defects that
together cause every API-backed page to fail silently. Symptom: pages render
but `get_*.php` endpoints return `{"error":"Service temporarily unavailable",
"data":[],"source":"api","count":0}` (78 bytes), and the JS-driven leaderboard
shows zeros for everyone. Verified against current DCSServerBot
`plugins/restapi/commands.py` -- none of these bugs are caused by VRS-side
customization; **any user running this dashboard against a current
key-gated DCSServerBot will hit them.**

Five commits, in narrative order. Each addresses one defect.

## Tested against

- **DCSServerBot:** v3.0.4.25, RestAPI plugin v1.4 (HEAD `5049073b`, 2026-05-05).
- **Dashboard base:** `Penfold-88/DCS-Statistics-Dashboard@main` (V1.0.0 + post-release commits).
- **Container:** PHP 8.2-fpm-alpine + nginx + supervisor (the upstream `Dockerfile`).
- **Live target:** a real production cluster running 4 DCS instances behind DCSServerBot's REST API with `X-API-Key` enabled. Leaderboard now returns ~1.8 KB of real player data with correct kills/KDR (was 78 bytes "Service unavailable" pre-fix).

## When did these bugs originate? (regression archaeology)

Walked `dcsserverbot/plugins/restapi/commands.py` history to date each defect. Three of the four are direct regressions from a roughly three-week window of REST API changes in August 2025; the fourth is a dashboard-side convention bug from day one.

| Bug | Origin in DCSServerBot | Date |
|---|---|---|
| Field rename `AAkills`/`AAKDR` -> `kills`/`kdr` | `d30bd364` "RestAPI: some field renamings" | **2025-08-09** |
| API key support added (initial custom `APIKeyBearer`) | `eda84a39` "RestAPI: Option for API key added to increase security" | 2025-08-23 |
| Auth scheme moved to `X-API-Key` header | `c9d37f69` "RestAPI: API key is stored in a different header field now" -- swaps `from .bearer import APIKeyBearer` -> `APIKeyHeader(name="X-API-Key")` | **2025-08-26** |
| POST verb on GET-only listing endpoints | Dashboard-side convention (the client's `makeRequest()` defaults to POST); the Bot's `/topkills`/`/topkdr` have always been FastAPI `Query`-param GET handlers since the plugin was first added (`a02026a7`, 2023-07-16) | n/a (pre-existing) |

The implication: the dashboard worked end-to-end against the Bot up to 2025-08-08. After 2025-08-09 the leaderboard silently zeroed-out (the `?? 0` fallback masked the rename). From 2025-08-23 onward, anyone who enabled the Bot's optional API key got 401s. The dashboard never caught up.

## What was wrong, and what each commit does

### 1. `api_proxy.php` sent no auth header at all

The JS-driven path (browser -> `api_proxy.php?endpoint=…` -> Bot) forwarded the
upstream call but never looked at `api_config.json`'s `api_key`, never set any
auth header. Once `DCSServerBot` enabled `X-API-Key` gating, every browser
request 401'd silently (the `get_*.php` wrappers turn 401 into the
"Service temporarily unavailable" message).

**Fix:** read `api_key` from the same `api_config.json` already loaded for
`api_base_url`, and forward it as `X-API-Key`. Merges with the
existing `Content-Type: application/x-www-form-urlencoded` header on POST so
neither overwrites the other.

### 2. `api_client.php` sent `Authorization: Bearer` -- DCSServerBot doesn't accept that

DCSServerBot's REST API is FastAPI with `APIKeyHeader(name="X-API-Key")` (see
`plugins/restapi/commands.py:91`). It does not accept `Authorization: Bearer`,
and returns 401 even with a valid key sent as Bearer.

**Fix:** one-line change: `'Authorization: Bearer ' . $this->apiKey` ->
`'X-API-Key: ' . $this->apiKey`.

### 3. `getTopKills` / `getTopKDR` used `POST` against GET-only endpoints

DCSServerBot defines listing endpoints (`/topkills`, `/topkdr`, `/servers`,
`/squadrons`, `/serverstats`) as FastAPI handlers with `Query` parameters
(`commands.py:1530` for `topkills`, `:1535` for `topkdr`), which makes them
GET-only. The client's `getTopKills()` / `getTopKDR()` issued POST and got
`405 Method Not Allowed`. The `*_api.php` files that call `$client->request(…)`
with an explicit verb were already correct; only these two convenience
wrappers were wrong.

**Fix:** flip the verb on both methods to GET.

Verb-by-endpoint, for reference (verified empirically + via Bot source):

| Endpoint | Method | Notes |
|---|---|---|
| `/topkills`, `/topkdr`, `/servers`, `/squadrons`, `/serverstats` | **GET** | Listing endpoints, FastAPI Query params |
| `/getuser`, `/stats`, `/weaponpk`, `/credits`, `/squadron_members`, `/squadron_credits` | **POST** | Lookups taking a body |

### 4. `get_leaderboard_api.php` read non-existent field names

The transform reads `$player['AAkills']` and `$player['AAKDR']`. DCSServerBot
returns `kills` and `kdr` -- see the SQL at `commands.py:1483-1489`
(`SUM(s.kills) AS "kills"`, `… AS "kdr"`). `AAkills` / `AAKDR` simply don't
exist anywhere in the response; the `?? 0` fallbacks render every player as
0 kills / 0 KDR.

The rest of the codebase already knows the right names -- the JS leaderboard
(via `api_proxy.php`) consumes `kills` and `kdr` directly. This was a stray
mistake in the server-side transform only.

**Fix:** match the field names DCSServerBot actually returns.

### 5. `health-check.php` was created by the Dockerfile, but the bind mount shadowed it

The Dockerfile's `RUN echo '<?php …' > /var/www/html/health-check.php` step
creates the file inside the image at build time. The default
`docker-compose.yml` bind-mounts `./dcs-stats:/var/www/html`, which shadows
that file with whatever's on the host. Result: the container's
`HEALTHCHECK CMD curl -f http://localhost/health-check.php` returns 404 and
the container reports `(unhealthy)` even when functioning normally.

**Fix:** commit `dcs-stats/health-check.php` (one line) so it's present whether
the bind mount is used or not. The Dockerfile's build-time creation becomes a
no-op fallback for non-compose direct-runs.

## How this was tested

- Deployed against a live DCSServerBot REST API on the VRS production cluster.
- Pre-fix: `curl /get_leaderboard.php` -> 78 bytes "Service unavailable".
- Post-fix: `curl /get_leaderboard.php` -> ~1.8 KB of real player data with
  correct kills/KDR. `/health-check.php` -> `OK`. Container reports `healthy`.
- The full diagnostic trail (Bot's response shape vs. client's expectation,
  exact PHP-fpm error messages from the masked catch block, etc.) is in the
  commit messages.

## Out of scope -- related upstream issue to follow

While debugging this, I also found that the Docker container's
**non-root user path (`RUN_AS_ROOT=false`, the recommended default) is
broken** -- nginx and php-fpm both crash-loop on permission denied for their
log paths. I'm filing a separate upstream issue for that one rather than
including a fix here, because the two sub-bugs (nginx log dir not chowned;
php-fpm master inheriting a root-owned stderr pipe from supervisor) need
more careful patching than the PHP fixes in this PR. **Workaround that
worked for us during testing: `RUN_AS_ROOT=true`** in `.env`. The PHP fixes
in this PR are independent of that issue and work in either mode.
