### PR TITLE
Dockerfile: deny direct access to .log/.sql/.json files in nginx config (api_config.json leak)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,18 @@ http {
         location ~ ^/(data|site-config/data)/ {
             deny all;
         }
-        
+
+        # Mirror dcs-stats/.htaccess intent: deny direct access to log, SQL,
+        # and JSON files. .htaccess is silently ignored under nginx, so the
+        # API key in api_config.json would otherwise be web-fetchable.
+        # Two JSON files JS callers need stay accessible via exact-match
+        # locations (higher priority than the regex deny below).
+        location = /server_data.json { try_files $uri =404; }
+        location = /mission_data.json { try_files $uri =404; }
+        location ~ \.(log|sql|json)$ {
+            deny all;
+        }
+
         location / {
             try_files $uri $uri/ /index.php?$query_string;
         }


### PR DESCRIPTION
## Summary

The dashboard ships `dcs-stats/.htaccess` which explicitly declares the intent
to deny direct GET on `.log`, `.sql`, and `.json` files (with an allowlist for
`server_data.json` and `mission_data.json` which JS callers need). Under the
official Docker path, that `.htaccess` is silently ignored because the
container serves traffic via **nginx**, not Apache.

The user-visible consequence is that **`api_config.json` is fetchable by
anyone who can reach the dashboard**:

```
$ curl http://<host>/api_config.json
{ "api_host": "...", "api_base_url": "...", "api_key": "<your DCSServerBot REST API key>", ... }
```

If the configured `api_key` is set (which it must be once
DCSServerBot's API key gating is enabled), this leaks the key in plaintext
on any request, no auth required.

## Fix

Translate the `.htaccess` intent into nginx `location` blocks inside the
Dockerfile's embedded server config. Exact-match locations take priority
over regex in nginx's location-matching algorithm, so the two allowed
JSON files keep working while the regex deny catches everything else:

```nginx
location = /server_data.json { try_files $uri =404; }
location = /mission_data.json { try_files $uri =404; }
location ~ \.(log|sql|json)$ {
    deny all;
}
```

Single commit, +12 / -1 lines, inside the existing `server { }` block
right after the existing data-directory deny.

## Verification

Tested against a live deployment of this dashboard with a configured
DCSServerBot REST API key:

| Path | Before | After |
|---|---|---|
| `/api_config.json` | `HTTP 200`, 1684 bytes (full config + key) | **`HTTP 403`, 146 bytes** |
| `/.version_meta.json` | already 403 via existing hidden-file rule | still 403 (no regression) |
| `/server_data.json` | n/a in this deploy | still 200 (allowlist works) |
| `/` (index) | 200, 25748 bytes | 200, 25748 bytes |
| `/leaderboard.php` | 200, 10958 bytes | 200, 10958 bytes |
| `/get_leaderboard.php` | 200, 1891 bytes (real player data) | 200, 1891 bytes (unchanged) |
| `/health-check.php` | 200, `OK` | 200, `OK` |

## Severity

If your deployment has a `api_key` populated in `api_config.json` (i.e.
DCSServerBot has its REST API key gating enabled), this is a credential
leak: anyone reaching the dashboard can read the Bot API key and then
issue arbitrary REST API calls against the Bot. **Worth treating as a
security fix.**

If the deployment has `api_key: null` (no Bot-side gating), the leak is
limited to architecture metadata (Bot URL and endpoint list).

## Related

PR #85 (separate, same author) fixes the dashboard's DCSServerBot REST
API integration itself (X-API-Key auth, HTTP verbs, field mapping). The
two PRs are independent.
